### PR TITLE
Add assorted Jibraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,12 @@ This repo is intended to provide a full list of lazy Java libraries that decided
 
 ## List of Jibraries
 
+* [AssertJ](https://assertj.github.io/doc/)
+* [JReleaser](https://jreleaser.org/)
+* [JUnit 4](https://junit.org/junit4/)
+* [JUnit 5](https://junit.org/junit5/)
 * [Jongo](https://jongo.org/)
 * [Jython](https://www.jython.org/)
+* [Log4j 2](https://logging.apache.org/log4j/2.x/)
+* [Log4j](https://logging.apache.org/log4j/1.2/)
+* [SLF4J](https://www.slf4j.org/)


### PR DESCRIPTION
As promised, added some more Jibraries to the list. JReleaser is not a Java library, but a tool instead. Similar to [JShell](https://docs.oracle.com/javase/9/jshell/). Shall we create a different section for those?